### PR TITLE
fix build break

### DIFF
--- a/src/ch/ch_migration.c
+++ b/src/ch/ch_migration.c
@@ -275,6 +275,7 @@ chDomainMigrationSrcConfirm(virCHDriverPtr driver,
     (void) driver;
     (void) flags;
     (void) cancelled;
-
+    (void) vm;
+    
     return -1;
 }


### PR DESCRIPTION
chDomainMigrationSrcConfirm  has unused variable "vm" so add it back to this function.

Signed-off-by: Vivek Yadav <vivek yadav@microsoft.com>